### PR TITLE
Update spherical_scattering.f90

### DIFF
--- a/src/scattering/spherical/spherical_scattering.f90
+++ b/src/scattering/spherical/spherical_scattering.f90
@@ -47,7 +47,7 @@ contains
         complex(knd) :: tmp1(matrix_size, matrix_size), tmp2(matrix_size, matrix_size), value
         integer :: n, l, s, maxd, lnum
         lnum = min(first%maxd, second%maxd)
-        call leg%set(first%m, first%m + lnum + 1, 1q0)
+        call leg%set(first%m, first%m + lnum + 1, 1.0_knd)
         call leg%calculate()
         P = 0
         do n = 1, matrix_size


### PR DESCRIPTION
3й аргумент функции leg%set имеет "общую" задаваемую точность, поэтому при knd != 16 программа ломалась. Теперь (как минимум, при knd = 8) все работает